### PR TITLE
Adds require prefix and fix call to compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 var through = require('through');
-var riotCompiler = require('riot/compiler');
+var riotCompiler = require('riot/compiler/compile');
 
 module.exports = function (file, o) {
   var opts = o;
   var content = '';
+  var reqriot = 'var riot = require(\'riot\');';
 
   return !file.match(/\.tag$/) ? through() : through(
     function (chunk) { // write
       content += chunk.toString();
     },
     function () { // end
-      this.queue(riotCompiler(content, opts));
+      this.queue(reqriot + riotCompiler(content, opts));
       this.emit('end');
     }
   );


### PR DESCRIPTION
This should address #1.

Looks like riot updated the interface for compiling. This PR requires the actual compile module instead of the higher level compiler.

Upon usage I noticed that if `riot` isn't declared globally the compiled tag file will cause an error when trying to register. I added a prefix to the transform output that requires `riot` and assigns it to a riot variable. Seems to do the trick!