### PR TITLE
Add the description for using with gulp.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ See more: https://muut.com/riotjs/compiler.html
 
 ### With gulp.js
 
-for JavaScript
-
 ```javascript
 var gulp       = require('gulp');
 var browserify = require('browserify');
@@ -82,31 +80,11 @@ var source     = require('vinyl-source-stream');
 
 gulp.task('browserify', function(){
   browserify({ entries: ['src/app.js'] })
-  .transform(riotify)
+  .transform(riotify, { template: 'jade' }) // pass options if you need
   .bundle()
   .pipe(source('app.js'))
   .pipe(gulp.dest('dist/'))
 });
-```
-
-for CoffeeScript
-
-```coffeescript
-gulp       = require 'gulp'
-browserify = require 'browserify'
-coffeeify  = require 'coffeeify'
-riotify    = require 'riotify'
-source     = require 'vinyl-source-stream'
-
-gulp.task 'browserify', ->
-  browserify
-    entries:    ['src/app.coffee']
-    extensions: ['.coffee', '.js']
-  .transform coffeeify
-  .transform riotify, type: 'coffeescript'
-  .bundle()
-  .pipe source 'app.js'
-  .pipe gulp.dest 'dist/'
 ```
 
 These are the simplest cases. `uglify` and `sourcemaps` would be needed.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,47 @@ You can also configure it in package.json
 
 See more: https://muut.com/riotjs/compiler.html
 
+### With gulp.js
+
+for JavaScript
+
+```javascript
+var gulp       = require('gulp');
+var browserify = require('browserify');
+var riotify    = require('riotify');
+var source     = require('vinyl-source-stream');
+
+gulp.task('browserify', function(){
+  browserify({ entries: ['src/app.js'] })
+  .transform(riotify)
+  .bundle()
+  .pipe(source('app.js'))
+  .pipe(gulp.dest('dist/'))
+});
+```
+
+for CoffeeScript
+
+```coffeescript
+gulp       = require 'gulp'
+browserify = require 'browserify'
+coffeeify  = require 'coffeeify'
+riotify    = require 'riotify'
+source     = require 'vinyl-source-stream'
+
+gulp.task 'browserify', ->
+  browserify
+    entries:    ['src/app.coffee']
+    extensions: ['.coffee', '.js']
+  .transform coffeeify
+  .transform riotify, type: 'coffeescript'
+  .bundle()
+  .pipe source 'app.js'
+  .pipe gulp.dest 'dist/'
+```
+
+These are the simplest cases. `uglify` and `sourcemaps` would be needed.
+
 ## Tests
 
     npm test


### PR DESCRIPTION
`transform` method can pass options like `{ type: 'coffeescript'  }`.
It took a little time to realize this for me, so it may help someone.