### PR TITLE
Add `skipStyle` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You can also configure it in package.json
   * JavaScript pre-processor
 * template: `String, jade`
   * HTML pre-processor
+* skipStyle: `Boolean`
+  * compile without `<style>...</style>`
 
 See more: https://muut.com/riotjs/compiler.html
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ var through = require('through');
 var riot = require('riot');
 var preamble = "var riot = require('riot');\n";
 
+skipStyle = function (str) {
+  var re = /<style>[\s\S]*<\/style>/gm;
+  return str.replace(re, '');
+}
+
 module.exports = function (file, o) {
   var opts = o;
   var content = '';
@@ -11,6 +16,7 @@ module.exports = function (file, o) {
       content += chunk.toString();
     },
     function () { // end
+      if (opts.skipStyle) content = skipStyle(content);
       this.queue(preamble + riot.compile(content, opts));
       this.emit('end');
     }


### PR DESCRIPTION
To use CSS preprocessors, I'd like to add this option.

This is an example use case.

```coffeescript
# riotify without style
gulp.task 'browserify', ->
  browserify
    entries: [$.app]
    debug: true
  .transform riotify, skipStyle: true
  .bundle()
  .pipe source path.basename $.app
  .pipe buffer()
  .pipe gulp.dest $.dist

# process style in tag file
gulp.task 'css', ->
  gulp.src [$.style, $.components]
  .pipe replace /(^[\s\S]*<style>|<\/style>[\s\S]*$)/gm, '' # extract style from tag file
  .pipe autoprefixer 'last 2 versions'
  .pipe concat 'style.css'
  .pipe gulp.dest $.dist
```

Related to https://github.com/muut/riotjs/issues/345