### PR TITLE
support specify --ext when invoke riot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.0.9
+
+  * Add custom extension support
+
+## 0.0.8
+
+  * Compatible with Riot 2.0.9
+
 ## 0.0.7
 
   * Add an explanation of compile options

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You can also configure it in package.json
   * JavaScript pre-processor
 * template: `String, jade`
   * HTML pre-processor
+* ext: `String`
+  * custom extension, you’re free to use any file extension for your tags (instead of default .tag):
 
 See more: https://muut.com/riotjs/compiler.html
 

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ var preamble = "var riot = require('riot');\n";
 module.exports = function (file, o) {
   var opts = o;
   var content = '';
+  var ext = o.ext || 'tag';
 
-  return !file.match(/\.tag$/) ? through() : through(
+  return !file.match('\.' + ext + '$') ? through() : through(
     function (chunk) { // write
       content += chunk.toString();
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riotify",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "browserify plugin for riot tag files",
   "main": "index.js",
   "dependencies": {

--- a/test/compile.js
+++ b/test/compile.js
@@ -38,3 +38,38 @@ test('compile', function (t) {
     t.ok(out[1].source.match(/riot.tag\(.*todo/), 'compiled compile.tag');
   }));
 });
+
+test('compile-custom-ext', function (t) {
+  var file = path.join(__dirname, 'customext.html');
+  var p = moduleDeps();
+
+  p.write({ transform: riotify, options: {ext: "html"} });
+  p.write({ file: file, id: file, entry: true });
+  p.end();
+
+  t.plan(6);
+  p.pipe(concat(function (out) {
+    t.is(out.length, 2, 'got two files as output');
+    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js');
+    t.ok(out[0].source.match(/module.exports/), 'riot.js');
+    t.ok(out[1].id.match(/customext\.html$/), 'out.1 is customext.html');
+    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot');
+    t.ok(out[1].source.match(/riot.tag\(.*customext/), 'compiled compile.tag');
+  }));
+});
+
+test('compile-custom-ext-ignore', function (t) {
+  var file = path.join(__dirname, 'todo.tag');
+  var p = moduleDeps();
+
+  p.write({ transform: riotify, options: {ext: "html"} });
+  p.write({ file: file, id: file, entry: true });
+  p.end();
+
+  t.plan(3);
+  p.pipe(concat(function (out) {
+    t.ok(out[0], 'got output element');
+    t.ok(out[0].source.length, 'got output element with source');
+    t.ok(out[0].source.match(/^<todo>/), 'skipped todo.tag');
+  }));
+});

--- a/test/customext.html
+++ b/test/customext.html
@@ -1,0 +1,7 @@
+<customext>
+  <div each={ items }>
+    <h3>{ title }</h3>
+  </div>
+
+  this.items = [ { title: 'First' }, { title: 'Second' } ]
+</customext>


### PR DESCRIPTION
latest riot supports custom extension, like --ext html. Change the regex logic here to support that.
Then we can do this: browserify -t [riotify --ext html] --extenstion=html -d src/index.js -o build/index.js