### PR TITLE
quick fix for defaulting options when undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (file, o) {
       content += chunk.toString();
     },
     function () { // end
-      this.queue(preamble + riot.compile(content, opts));
+      this.queue(preamble + 'module.exports = ' + riot.compile(content, opts));
       this.emit('end');
     }
   );

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var riot = require('riot');
 var preamble = "var riot = require('riot');\n";
 
 module.exports = function (file, o) {
-  var opts = o;
+  var opts = o || {};
+  var ext = opts.ext || 'tag';
   var content = '';
-  var ext = o.ext || 'tag';
 
   return !file.match('\.' + ext + '$') ? through() : through(
     function (chunk) { // write

--- a/test/compile.js
+++ b/test/compile.js
@@ -73,3 +73,17 @@ test('compile-custom-ext-ignore', function (t) {
     t.ok(out[0].source.match(/^<todo>/), 'skipped todo.tag');
   }));
 });
+
+test('module exports riot tag', function (t) {
+  var file = path.join(__dirname, 'todo.tag');
+  var p = moduleDeps();
+
+  p.write({ transform: riotify });
+  p.write({ file: file, id: file, entry: true });
+  p.end();
+
+  t.plan(1);
+  p.pipe(concat(function (out) {
+    t.ok(out[1].source.match(/module.exports = riot.tag/), 'riot tag');
+  }));
+});


### PR DESCRIPTION
quick fix to allow use the following syntax:

```
var timer = require('./tags/timer.tag')
riot.mount(timer)
```

similar to what we have in riot for server-side rendering
