### PR TITLE
Emit error event on compile error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ module.exports = function (file, o) {
       content += chunk.toString();
     },
     function () { // end
-      this.queue(preamble + 'module.exports = ' + riot.compile(content, opts));
-      this.emit('end');
+      try {
+        this.queue(preamble + 'module.exports = ' + riot.compile(content, opts));
+        this.emit('end');
+      } catch (e) {
+        this.emit('error', e);
+      }
     }
   );
 };


### PR DESCRIPTION
This means that the entire browserify session doesn't die if you're
using it via the node api. 

I ran into this while using riotify via a gulp watchfile, which would annoyingly stop every time a riot compile failed.