### PR TITLE
Update README.md - added in example of using require in a tag file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Example `todo.tag`:
       <div each={ items }>
         <h3>{ title }</h3>
       </div>
-
-      this.items = [ { title: 'First' }, { title: 'Second' } ]
+      
+      // a tag file can contain any JavaScript, even require()
+      var resources = require('../resources.json')    
+      this.items = [ { title: resources.en.first }, { title: resources.en.second } ]
     </todo>
 
 Note that your tag files actually need to have the extension ".tag".


### PR DESCRIPTION
This transform is really nice and does exactly what I was looking for, but I was not able to tell that this is the case from the README, since I was interested in whether `require` calls would work from inside a tag file. They do, so I thought I'd add it to the README.