### PR TITLE
Passing the file name to the riot compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (file, o) {
     },
     function () { // end
       try {
-        this.queue(preamble + 'module.exports = ' + riot.compile(content, opts));
+        this.queue(preamble + 'module.exports = ' + riot.compile(content, opts, file));
         this.emit('end');
       } catch (e) {
         this.emit('error', e);


### PR DESCRIPTION
When using the Jade template preprocessing, it is impossible to include some chunk of Jade template into a riot tag compiled with this transform.

```
partial.jade :
  This is my partial content
---
mycomponent.tag :
  mycomponent
    h1 My Component
    include ./partial.jade   
```

This fixes the issue